### PR TITLE
combiner: combine two tables via join or extend

### DIFF
--- a/transforms/README.md
+++ b/transforms/README.md
@@ -6,13 +6,11 @@
 ## Usage
 
 ```go
-const (
-	// LeftJoin - Always add row from Left table, even if no corresponding rows found in Right table)
-	LeftJoin = iota
-	// InnerJoin - Only add row from Left table if corresponding row(s) found in Right table)
-	InnerJoin
-)
+var JoinType = joinStruct{Left: joinType{0}, Inner: joinType{1}}
 ```
+Left: Always add row from Left table, even if no corresponding rows found in
+Right table) Inner: Only add row from Left table if corresponding row(s) found
+in Right table)
 
 #### func  Each
 
@@ -33,7 +31,7 @@ mapping applied.
 #### func  Join
 
 ```go
-func Join(rightTable optimus.Table, leftHeader string, rightHeader string, joinType int) optimus.TransformFunc
+func Join(rightTable optimus.Table, leftHeader string, rightHeader string, join joinType) optimus.TransformFunc
 ```
 Join returns a Table that combines fields with another table, joining via
 joinType

--- a/transforms/transforms.go
+++ b/transforms/transforms.go
@@ -79,15 +79,20 @@ func Valuemap(mappings map[string]map[interface{}]interface{}) optimus.Transform
 	})
 }
 
-const (
-	// LeftJoin - Always add row from Left table, even if no corresponding rows found in Right table)
-	LeftJoin = iota
-	// InnerJoin - Only add row from Left table if corresponding row(s) found in Right table)
-	InnerJoin
-)
+type joinStruct struct {
+	Left, Inner joinType
+}
+
+type joinType struct {
+	int
+}
+
+// Left: Always add row from Left table, even if no corresponding rows found in Right table)
+// Inner: Only add row from Left table if corresponding row(s) found in Right table)
+var JoinType = joinStruct{Left: joinType{0}, Inner: joinType{1}}
 
 // Join returns a Table that combines fields with another table, joining via joinType
-func Join(rightTable optimus.Table, leftHeader string, rightHeader string, joinType int) optimus.TransformFunc {
+func Join(rightTable optimus.Table, leftHeader string, rightHeader string, join joinType) optimus.TransformFunc {
 	hash := make(map[interface{}][]optimus.Row)
 
 	// Build hash from right table
@@ -118,7 +123,7 @@ func Join(rightTable optimus.Table, leftHeader string, rightHeader string, joinT
 					out <- mergeRows(leftRow, rightRow)
 				}
 			} else {
-				if joinType == LeftJoin {
+				if join == JoinType.Left {
 					out <- leftRow
 				}
 			}

--- a/transforms/transforms_test.go
+++ b/transforms/transforms_test.go
@@ -126,7 +126,7 @@ func TestJoinOneToOne(t *testing.T) {
 		{"header3": "value5", "header4": "value9"},
 	})
 
-	combinedTable := optimus.Transform(leftTable, Join(rightTable, "header1", "header3", InnerJoin))
+	combinedTable := optimus.Transform(leftTable, Join(rightTable, "header1", "header3", JoinType.Inner))
 
 	rows := tests.HasRows(t, combinedTable, 3)
 	assert.Equal(t, expected, rows)
@@ -145,7 +145,7 @@ func TestJoinOneToNone(t *testing.T) {
 		{"header3": "value3", "header4": "value8"},
 		{"header3": "value5", "header4": "value9"},
 	})
-	combinedTable := optimus.Transform(leftTable, Join(rightTable, "header1", "header3", InnerJoin))
+	combinedTable := optimus.Transform(leftTable, Join(rightTable, "header1", "header3", JoinType.Inner))
 	rows := tests.HasRows(t, combinedTable, 2)
 	assert.Equal(t, expected, rows)
 }
@@ -164,7 +164,7 @@ func TestJoinOneToMany(t *testing.T) {
 		{"header3": "value1", "header4": "value8"},
 		{"header3": "value1", "header4": "value9"},
 	})
-	combinedTable := optimus.Transform(leftTable, Join(rightTable, "header1", "header3", InnerJoin))
+	combinedTable := optimus.Transform(leftTable, Join(rightTable, "header1", "header3", JoinType.Inner))
 	rows := tests.HasRows(t, combinedTable, 2)
 	assert.Equal(t, expected, rows)
 }
@@ -182,7 +182,7 @@ func TestJoinManyToOne(t *testing.T) {
 		{"header3": "value1", "header4": "value8"},
 	})
 
-	combinedTable := optimus.Transform(leftTable, Join(rightTable, "header1", "header3", InnerJoin))
+	combinedTable := optimus.Transform(leftTable, Join(rightTable, "header1", "header3", JoinType.Inner))
 
 	rows := tests.HasRows(t, combinedTable, 2)
 	assert.Equal(t, expected, rows)
@@ -204,7 +204,7 @@ func TestJoinManyToMany(t *testing.T) {
 		{"header3": "value1", "header4": "value5"},
 	})
 
-	combinedTable := optimus.Transform(leftTable, Join(rightTable, "header1", "header3", InnerJoin))
+	combinedTable := optimus.Transform(leftTable, Join(rightTable, "header1", "header3", JoinType.Inner))
 
 	rows := tests.HasRows(t, combinedTable, 4)
 	assert.Equal(t, expected, rows)
@@ -221,7 +221,7 @@ func TestLeftOverwritesRight(t *testing.T) {
 		{"header3": "value1", "header1": "value3"},
 	})
 
-	combinedTable := optimus.Transform(leftTable, Join(rightTable, "header1", "header3", InnerJoin))
+	combinedTable := optimus.Transform(leftTable, Join(rightTable, "header1", "header3", JoinType.Inner))
 
 	rows := tests.HasRows(t, combinedTable, 1)
 	assert.Equal(t, expected, rows)
@@ -240,7 +240,7 @@ func TestLeftJoin(t *testing.T) {
 		{"header3": "value1", "header4": "value5"},
 	})
 
-	combinedTable := optimus.Transform(leftTable, Join(rightTable, "header1", "header3", LeftJoin))
+	combinedTable := optimus.Transform(leftTable, Join(rightTable, "header1", "header3", JoinType.Left))
 
 	rows := tests.HasRows(t, combinedTable, 2)
 	assert.Equal(t, expected, rows)
@@ -256,7 +256,7 @@ func TestRightTableTransformError(t *testing.T) {
 	rightTable = optimus.Transform(rightTable, TableTransform(func(row optimus.Row, out chan<- optimus.Row) error {
 		return errors.New("some error")
 	}))
-	combinedTable := optimus.Transform(leftTable, Join(rightTable, "header1", "header3", InnerJoin))
+	combinedTable := optimus.Transform(leftTable, Join(rightTable, "header1", "header3", JoinType.Inner))
 
 	// Should receive no rows here because the first response was an error.
 	tests.Consumed(t, combinedTable)


### PR DESCRIPTION
This implements
- an INNER join
- extend (append rows from table2 to table1)

Would love your feedback on
1. If join / extend are in scope for optimus
2. What interfaces are most appropriate for these methods
3. Suggested optimizations. Currently, this is a naive implementation, so I would like to optimize it substantially and better utilize golang 

Thanks!

![image](https://cloud.githubusercontent.com/assets/102242/3275109/b95cec6a-f337-11e3-90d5-c1c75433202d.png)
