### PR TITLE
sinks: csv: consistent write order

### DIFF
--- a/sinks/csv/README.md
+++ b/sinks/csv/README.md
@@ -11,4 +11,4 @@
 func New(source optimus.Table, filename string) error
 ```
 New writes all of the Rows in a Table to a CSV file. It assumes that all Rows
-have the same headers.
+have the same headers. Columns are written in alphabetical order.

--- a/sinks/csv/csv.go
+++ b/sinks/csv/csv.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"gopkg.in/azylman/optimus.v1"
 	"os"
+	"sort"
 )
 
 func convertRowToRecord(row optimus.Row, headers []string) []string {
@@ -27,7 +28,7 @@ func convertRowToHeader(row optimus.Row) []string {
 }
 
 // New writes all of the Rows in a Table to a CSV file. It assumes that all Rows have the same
-// headers.
+// headers. Columns are written in alphabetical order.
 func New(source optimus.Table, filename string) error {
 	fout, err := os.Create(filename)
 	defer fout.Close()
@@ -40,6 +41,7 @@ func New(source optimus.Table, filename string) error {
 	for row := range source.Rows() {
 		if !wroteHeader {
 			headers = convertRowToHeader(row)
+			sort.Strings(headers)
 			if err := writer.Write(headers); err != nil {
 				return err
 			}

--- a/sinks/csv/csv_test.go
+++ b/sinks/csv/csv_test.go
@@ -38,6 +38,14 @@ func TestNilValues(t *testing.T) {
 	assert.Equal(t, actual, []string{"field1,field2", `val1,""`, ""})
 }
 
+func TestAlphabetical(t *testing.T) {
+	source := slice.New([]optimus.Row{{"a": "0", "b": "0", "c": "0", "d": "0", "e": "0", "f": "0"}})
+	assert.Nil(t, New(source, "./data_write.csv"))
+	actual, err := readFile("./data_write.csv")
+	assert.Nil(t, err)
+	assert.Equal(t, actual[0], "a,b,c,d,e,f")
+}
+
 type errorTable struct {
 	rows chan optimus.Row
 }


### PR DESCRIPTION
Otherwise tests sometimes fail on go 1.3, which fixes iteration order for small maps
