### PR TITLE
transforms: fieldmap shouldnt map nil values when passed nonexisting headers

### DIFF
--- a/tests/test_table.go
+++ b/tests/test_table.go
@@ -1,8 +1,8 @@
 package tests
 
 import (
-	"gopkg.in/azylman/optimus.v1"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/azylman/optimus.v1"
 	"testing"
 )
 
@@ -55,7 +55,11 @@ func CompareTables(t *testing.T, configs []TableCompareConfig) {
 		actual := GetRows(actualTable)
 		if config.Expected != nil {
 			expected := GetRows(config.Expected(config.Source(), config.Arg))
-			assert.Equal(t, expected, actual, "%s failed", config.Name)
+			for idx, expectedRow := range expected {
+				for field_name, _ := range expectedRow {
+					assert.Equal(t, expected[idx][field_name], actual[idx][field_name], "%s failed", config.Name)
+				}
+			}
 		} else if config.Error != nil {
 			assert.Equal(t, config.Error, actualTable.Err())
 		} else {

--- a/transforms/transforms.go
+++ b/transforms/transforms.go
@@ -59,7 +59,9 @@ func Fieldmap(mappings map[string][]string) optimus.TransformFunc {
 		newRow := optimus.Row{}
 		for key, vals := range mappings {
 			for _, val := range vals {
-				newRow[val] = row[key]
+				if oldRowVal, ok := row[key]; ok {
+					newRow[val] = oldRowVal
+				}
 			}
 		}
 		return newRow, nil

--- a/transforms/transforms_test.go
+++ b/transforms/transforms_test.go
@@ -25,9 +25,48 @@ var defaultSource = func() optimus.Table {
 
 var transformEqualities = []tests.TableCompareConfig{
 	{
-		Name: "Fieldmap",
+		Name: "Fieldmap-MapSome",
 		Actual: func(optimus.Table, interface{}) optimus.Table {
 			return optimus.Transform(defaultSource(), Fieldmap(map[string][]string{"header1": {"header4"}}))
+		},
+		Expected: func(optimus.Table, interface{}) optimus.Table {
+			return slice.New([]optimus.Row{
+				{"header4": "value1"},
+				{"header4": "value3"},
+				{"header4": "value5"},
+			})
+		},
+	},
+	{
+		Name: "Fieldmap-MapAll",
+		Actual: func(optimus.Table, interface{}) optimus.Table {
+			return optimus.Transform(defaultSource(), Fieldmap(map[string][]string{"header1": {"header4"}, "header2": {"header5"}}))
+		},
+		Expected: func(optimus.Table, interface{}) optimus.Table {
+			return slice.New([]optimus.Row{
+				{"header4": "value1", "header5": "value2"},
+				{"header4": "value3", "header5": "value4"},
+				{"header4": "value5", "header5": "value6"},
+			})
+		},
+	},
+	{
+		Name: "Fieldmap-MapOneToMany",
+		Actual: func(optimus.Table, interface{}) optimus.Table {
+			return optimus.Transform(defaultSource(), Fieldmap(map[string][]string{"header1": {"header4", "header6"}}))
+		},
+		Expected: func(optimus.Table, interface{}) optimus.Table {
+			return slice.New([]optimus.Row{
+				{"header4": "value1", "header6": "value1"},
+				{"header4": "value3", "header6": "value1"},
+				{"header4": "value5", "header6": "value1"},
+			})
+		},
+	},
+	{
+		Name: "Fieldmap-IgnoreInvalidMap",
+		Actual: func(optimus.Table, interface{}) optimus.Table {
+			return optimus.Transform(defaultSource(), Fieldmap(map[string][]string{"header1": {"header4"}, "headerFake": {"headerDoesntMap"}}))
 		},
 		Expected: func(optimus.Table, interface{}) optimus.Table {
 			return slice.New([]optimus.Row{


### PR DESCRIPTION
see transforms_test `Fieldmap-IgnoreInvalidMap` for an example of the behavior after adding the modification

@azylman your thoughts on this change? (and additional tests to clarify the behaviors of fieldmap)
