### PR TITLE
Support configurable csv delimiters

### DIFF
--- a/sinks/csv/README.md
+++ b/sinks/csv/README.md
@@ -13,11 +13,11 @@ func New(out io.Writer) optimus.Sink
 New writes all of the Rows in a Table to a CSV file. It assumes that all Rows
 have the same headers. Columns are written in alphabetical order.
 
-#### func  NewWithDelimiter
+#### func  NewWithCsvWriter
 
 ```go
-func NewWithDelimiter(out io.Writer, delimiter rune) optimus.Sink
+func NewWithCsvWriter(writer *csv.Writer) optimus.Sink
 ```
-NewWithDelimiter writes all of the Rows in a Table to a CSV file delimited as
-specified. It assumes that all Rows have the same headers. Columns are written
-in alphabetical order.
+NewWithCsvWriter writes all of the Rows in a Table to a CSV file using the
+options in the CSV writer. It assumes that all Rows have the same headers.
+Columns are written in alphabetical order.

--- a/sinks/csv/csv.go
+++ b/sinks/csv/csv.go
@@ -31,15 +31,13 @@ func convertRowToHeader(row optimus.Row) []string {
 // New writes all of the Rows in a Table to a CSV file. It assumes that all Rows have the same
 // headers. Columns are written in alphabetical order.
 func New(out io.Writer) optimus.Sink {
-	return NewWithDelimiter(out, ',')
+	return NewWithCsvWriter(csv.NewWriter(out))
 }
 
-// NewWithDelimiter writes all of the Rows in a Table to a CSV file delimited as specified. It assumes
-// that all Rows have the same headers. Columns are written in alphabetical order.
-func NewWithDelimiter(out io.Writer, delimiter rune) optimus.Sink {
+// NewWithCsvWriter writes all of the Rows in a Table to a CSV file using the options in the CSV writer.
+// It assumes that all Rows have the same headers. Columns are written in alphabetical order.
+func NewWithCsvWriter(writer *csv.Writer) optimus.Sink {
 	return func(source optimus.Table) error {
-		writer := csv.NewWriter(out)
-		writer.Comma = delimiter
 		headers := []string{}
 		wroteHeader := false
 		for row := range source.Rows() {

--- a/sinks/csv/csv_test.go
+++ b/sinks/csv/csv_test.go
@@ -2,6 +2,7 @@ package csv
 
 import (
 	"bytes"
+	csvEncoding "encoding/csv"
 	"errors"
 	"strings"
 	"testing"
@@ -27,9 +28,11 @@ func TestCSVSink(t *testing.T) {
 	assert.Equal(t, actual.String(), csvData)
 }
 
-func TestTabSink(t *testing.T) {
+func TestTabSync(t *testing.T) {
 	actual := &bytes.Buffer{}
-	assert.Nil(t, NewWithDelimiter(actual, '\t')(csv.New(bytes.NewBufferString(csvData))))
+	writer := csvEncoding.NewWriter(actual)
+	writer.Comma = '\t'
+	assert.Nil(t, NewWithCsvWriter(writer)(csv.New(bytes.NewBufferString(csvData))))
 	assert.Equal(t, actual.String(), tabData)
 }
 

--- a/sources/csv/README.md
+++ b/sources/csv/README.md
@@ -12,10 +12,10 @@ func New(in io.Reader) optimus.Table
 ```
 New returns a new Table that scans over the rows of a CSV.
 
-#### func  NewWithDelimiter
+#### func  NewWithCsvReader
 
 ```go
-func NewWithDelimiter(in io.Reader, delimiter rune) optimus.Table
+func NewWithCsvReader(reader *csv.Reader) optimus.Table
 ```
-NewWithDelimiter returns a new Table that scans over the rows of a CSV delimited
-as specified.
+NewWithCsvReader returns a new Table that scans over the rows from the csv
+reader.

--- a/sources/csv/csv.go
+++ b/sources/csv/csv.go
@@ -13,12 +13,9 @@ type table struct {
 	stopped bool
 }
 
-func (t *table) start(in io.Reader, delimiter rune) {
+func (t *table) start(reader *csv.Reader) {
 	defer t.Stop()
 	defer close(t.rows)
-
-	reader := csv.NewReader(in)
-	reader.Comma = delimiter
 
 	headers, err := reader.Read()
 	if err != nil {
@@ -71,14 +68,14 @@ func convertLineToRow(line []string, headers []string) optimus.Row {
 
 // New returns a new Table that scans over the rows of a CSV.
 func New(in io.Reader) optimus.Table {
-	return NewWithDelimiter(in, ',')
+	return NewWithCsvReader(csv.NewReader(in))
 }
 
-// NewWithDelimiter returns a new Table that scans over the rows of a CSV delimited as specified.
-func NewWithDelimiter(in io.Reader, delimiter rune) optimus.Table {
+// NewWithCsvReader returns a new Table that scans over the rows from the csv reader.
+func NewWithCsvReader(reader *csv.Reader) optimus.Table {
 	table := &table{
 		rows: make(chan optimus.Row),
 	}
-	go table.start(in, delimiter)
+	go table.start(reader)
 	return table
 }

--- a/sources/csv/csv_test.go
+++ b/sources/csv/csv_test.go
@@ -2,6 +2,7 @@ package csv
 
 import (
 	"bytes"
+	"encoding/csv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,7 +30,9 @@ func TestCSVSource(t *testing.T) {
 }
 
 func TestTabSource(t *testing.T) {
-	table := NewWithDelimiter(bytes.NewBufferString(tabData), '\t')
+	reader := csv.NewReader(bytes.NewBufferString(tabData))
+	reader.Comma = '\t'
+	table := NewWithCsvReader(reader)
 	assert.Equal(t, expected, tests.GetRows(table))
 	assert.Nil(t, table.Err())
 }


### PR DESCRIPTION
Previously, the `csv` source didn't allow configuration of CSV options and would always use the defaults. This means that lots of things were impossible, e.g. reading a tab-delimited file.

This change maintains the old function for backwards compatibility, but adds a new function that creates a `csv` source from a `csv.Reader`, allowing the consumer to specify any options they desire.

We test this by making an `io.Reader` with tab-delimited CSV data, making a `csv` source from it, and verifying that we get the correct data from the `Table`.
