### PR TITLE
transformer: add Pair method

### DIFF
--- a/transformer/README.md
+++ b/transformer/README.md
@@ -63,6 +63,14 @@ func (t *Transformer) Map(transform func(optimus.Row) (optimus.Row, error)) *Tra
 ```
 Map Applies a Map transform.
 
+#### func (*Transformer) Pair
+
+```go
+func (t *Transformer) Pair(rightTable optimus.Table, leftID, rightID transforms.RowIdentifier,
+	filterFn func(optimus.Row) (bool, error)) *Transformer
+```
+Pair Applies a Pair transform.
+
 #### func (*Transformer) Reduce
 
 ```go

--- a/transformer/transformer.go
+++ b/transformer/transformer.go
@@ -67,6 +67,12 @@ func (t *Transformer) Concat(tables ...optimus.Table) *Transformer {
 	return t.Apply(transforms.Concat(tables...))
 }
 
+// Pair Applies a Pair transform.
+func (t *Transformer) Pair(rightTable optimus.Table, leftID, rightID transforms.RowIdentifier,
+	filterFn func(optimus.Row) (bool, error)) *Transformer {
+	return t.Apply(transforms.Pair(rightTable, leftID, rightID, filterFn))
+}
+
 // Sink consumes all the Rows.
 func (t *Transformer) Sink(sink optimus.Sink) error {
 	return sink(t.table)


### PR DESCRIPTION
I think the `transformer` package is a ripe target for `go generate`, to automatically generate a method for every built-in `TransformFunc`.