### PR TITLE
add transforms.StableSort

### DIFF
--- a/transforms/README.md
+++ b/transforms/README.md
@@ -112,6 +112,14 @@ func Sort(less func(i, j optimus.Row) (bool, error)) optimus.TransformFunc
 Sort takes in a function that reports whether the row i should sort before row
 j. It outputs the rows in sorted order. The sort is not guaranteed to be stable.
 
+#### func  StableSort
+
+```go
+func StableSort(less func(i, j optimus.Row) (bool, error)) optimus.TransformFunc
+```
+StableSort takes in a function that reports whether the row i should sort before
+row j. It outputs the rows in stably sorted order.
+
 #### func  TableTransform
 
 ```go

--- a/transforms/sort_test.go
+++ b/transforms/sort_test.go
@@ -2,11 +2,12 @@ package transforms
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/Clever/optimus.v3"
 	"gopkg.in/Clever/optimus.v3/sources/slice"
 	"gopkg.in/Clever/optimus.v3/tests"
-	"testing"
 )
 
 func byStringKey(key string) func(optimus.Row, optimus.Row) (bool, error) {
@@ -62,17 +63,54 @@ var sortTests = []struct {
 
 func TestSort(t *testing.T) {
 	for _, sortTest := range sortTests {
-		input := slice.New(sortTest.input)
-		sort := Sort(sortTest.less)
-		table := optimus.Transform(input, sort)
+		for _, sort := range []optimus.TransformFunc{Sort(sortTest.less), StableSort(sortTest.less)} {
+			input := slice.New(sortTest.input)
+			table := optimus.Transform(input, sort)
 
-		actual := tests.GetRows(table)
+			actual := tests.GetRows(table)
 
-		if sortTest.err != nil {
-			assert.Equal(t, sortTest.err, table.Err())
-		} else {
-			assert.Equal(t, actual, sortTest.output)
-			assert.Nil(t, table.Err())
+			if sortTest.err != nil {
+				assert.Equal(t, sortTest.err, table.Err())
+			} else {
+				assert.Equal(t, actual, sortTest.output)
+				assert.Nil(t, table.Err())
+			}
 		}
 	}
+}
+
+func TestStable(t *testing.T) {
+	input := []optimus.Row{
+		{"c": "a", "b": "a"},
+		{"c": "a", "b": "b"},
+		{"c": "a", "b": "c"},
+		{"c": "a", "b": "d"},
+		{"c": "a", "b": "e"},
+		{"c": "a", "b": "f"},
+		{"c": "a", "b": "g"},
+		{"c": "a", "b": "h"},
+		{"c": "a", "b": "i"},
+		{"c": "a", "b": "j"},
+		{"c": "a", "b": "k"},
+		{"c": "a", "b": "l"},
+		{"c": "a", "b": "m"},
+		{"c": "a", "b": "n"},
+		{"c": "a", "b": "o"},
+		{"c": "a", "b": "p"},
+		{"c": "a", "b": "q"},
+		{"c": "a", "b": "r"},
+		{"c": "a", "b": "s"},
+		{"c": "a", "b": "t"},
+		{"c": "a", "b": "u"},
+		{"c": "a", "b": "v"},
+		{"c": "a", "b": "w"},
+		{"c": "a", "b": "x"},
+		{"c": "a", "b": "y"},
+		{"c": "a", "b": "z"},
+	}
+
+	table := optimus.Transform(slice.New(input), StableSort(byStringKey("c")))
+	actual := tests.GetRows(table)
+	assert.Nil(t, table.Err())
+	assert.Equal(t, actual, input)
 }

--- a/transforms/transforms.go
+++ b/transforms/transforms.go
@@ -1,9 +1,10 @@
 package transforms
 
 import (
+	"sync"
+
 	"gopkg.in/Clever/optimus.v3"
 	"gopkg.in/fatih/set.v0"
-	"sync"
 )
 
 // TableTransform returns a TransformFunc that applies the given transform function.


### PR DESCRIPTION
For those times when you want a stable sort.

I didn't see a need to test that the result is stably sorted - that seemed to me redundant with existing tests for `sort.Stable`. I mostly want to test that we correctly use + interpret the `Less` function that's passed in, so I re-used the tests for unstable `Sort`.