### PR TITLE
call source.Stop() in json & csv sink

### DIFF
--- a/sinks/csv/csv.go
+++ b/sinks/csv/csv.go
@@ -38,6 +38,7 @@ func New(out io.Writer) optimus.Sink {
 // It assumes that all Rows have the same headers. Columns are written in alphabetical order.
 func NewWithCsvWriter(writer *csv.Writer) optimus.Sink {
 	return func(source optimus.Table) error {
+		defer source.Stop()
 		headers := []string{}
 		wroteHeader := false
 		for row := range source.Rows() {

--- a/sinks/csv/csv_test.go
+++ b/sinks/csv/csv_test.go
@@ -52,5 +52,7 @@ func TestAlphabetical(t *testing.T) {
 }
 
 func TestCSVSinkError(t *testing.T) {
-	assert.EqualError(t, New(&bytes.Buffer{})(errorSource.New(errors.New("failed"))), "failed")
+	source := errorSource.New(errors.New("failed"))
+	assert.EqualError(t, New(&bytes.Buffer{})(source), "failed")
+	assert.True(t, source.Stopped)
 }

--- a/sinks/json/json.go
+++ b/sinks/json/json.go
@@ -2,13 +2,15 @@ package csv
 
 import (
 	"encoding/json"
-	"gopkg.in/Clever/optimus.v3"
 	"io"
+
+	"gopkg.in/Clever/optimus.v3"
 )
 
 // New writes all of the Rows in a Table as newline-separate JSON objects.
 func New(out io.Writer) optimus.Sink {
 	return func(source optimus.Table) error {
+		defer source.Stop()
 		for row := range source.Rows() {
 			obj, err := json.Marshal(row)
 			if err != nil {

--- a/sinks/json/json_test.go
+++ b/sinks/json/json_test.go
@@ -3,10 +3,11 @@ package csv
 import (
 	"bytes"
 	"errors"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	errorSource "gopkg.in/Clever/optimus.v3/sources/error"
 	"gopkg.in/Clever/optimus.v3/sources/json"
-	"testing"
 )
 
 var jsonData = `{"header1":"field1","header2":"field2","header3":"field3"}
@@ -21,5 +22,7 @@ func TestJSONSink(t *testing.T) {
 }
 
 func TestJSONSinkError(t *testing.T) {
-	assert.EqualError(t, New(&bytes.Buffer{})(errorSource.New(errors.New("failed"))), "failed")
+	source := errorSource.New(errors.New("failed"))
+	assert.EqualError(t, New(&bytes.Buffer{})(source), "failed")
+	assert.True(t, source.Stopped)
 }

--- a/sources/error/README.md
+++ b/sources/error/README.md
@@ -5,10 +5,37 @@
 
 ## Usage
 
+#### type ErrorTable
+
+```go
+type ErrorTable struct {
+	Stopped bool
+}
+```
+
+
 #### func  New
 
 ```go
-func New(err error) optimus.Table
+func New(err error) *ErrorTable
 ```
 New returns a new Table that returns a given error. Primarily used for testing
 purposes.
+
+#### func (*ErrorTable) Err
+
+```go
+func (e *ErrorTable) Err() error
+```
+
+#### func (*ErrorTable) Rows
+
+```go
+func (e *ErrorTable) Rows() <-chan optimus.Row
+```
+
+#### func (*ErrorTable) Stop
+
+```go
+func (e *ErrorTable) Stop()
+```

--- a/sources/error/error.go
+++ b/sources/error/error.go
@@ -4,24 +4,27 @@ import (
 	"gopkg.in/Clever/optimus.v3"
 )
 
-type errorTable struct {
-	rows chan optimus.Row
-	err  error
+type ErrorTable struct {
+	rows    chan optimus.Row
+	err     error
+	Stopped bool
 }
 
-func (e errorTable) Err() error {
+func (e *ErrorTable) Err() error {
 	return e.err
 }
 
-func (e errorTable) Rows() <-chan optimus.Row {
+func (e *ErrorTable) Rows() <-chan optimus.Row {
 	return e.rows
 }
 
-func (e errorTable) Stop() {}
+func (e *ErrorTable) Stop() {
+	e.Stopped = true
+}
 
 // New returns a new Table that returns a given error. Primarily used for testing purposes.
-func New(err error) optimus.Table {
-	table := &errorTable{err: err, rows: make(chan optimus.Row)}
+func New(err error) *ErrorTable {
+	table := &ErrorTable{err: err, rows: make(chan optimus.Row)}
 	close(table.rows)
 	return table
 }


### PR DESCRIPTION
If `source.Stop()` is not called in `jsonSink.New` and `csvSink.New`, it is possible that the `Stop()` never gets called if there is an error. This provides a fix for that case.

Testing: Tested manually, and added to the existing tests for json & csv sink.