### PR TITLE
Adds warning about delimiter for sources/csv

### DIFF
--- a/sources/csv/csv.go
+++ b/sources/csv/csv.go
@@ -2,8 +2,8 @@ package csv
 
 import (
 	"encoding/csv"
+	"fmt"
 	"io"
-	"log"
 
 	"gopkg.in/Clever/optimus.v3"
 )
@@ -19,10 +19,11 @@ func (t *table) start(reader *csv.Reader) {
 	defer close(t.rows)
 
 	headers, err := reader.Read()
-	if _, ok := err.(*csv.ParseError); ok {
-		log.Printf("csv.go received encoding/csv.ErrQuote, this can happen when a csv uses the wrong delimiter. Current delimiter is %q.", reader.Comma)
-	}
 	if err != nil {
+		if perr, ok := err.(*csv.ParseError); ok {
+			// Modifies the underlying err
+			perr.Err = fmt.Errorf("%s. %s", perr.Err, "This can happen when the CSV is malformed, or when the wrong delimiter is used")
+		}
 		t.handleErr(err)
 		return
 	}

--- a/sources/csv/csv.go
+++ b/sources/csv/csv.go
@@ -3,6 +3,7 @@ package csv
 import (
 	"encoding/csv"
 	"io"
+	"log"
 
 	"gopkg.in/Clever/optimus.v3"
 )
@@ -18,6 +19,9 @@ func (t *table) start(reader *csv.Reader) {
 	defer close(t.rows)
 
 	headers, err := reader.Read()
+	if _, ok := err.(*csv.ParseError); ok {
+		log.Printf("csv.go received encoding/csv.ErrQuote, this can happen when a csv uses the wrong delimiter. Current delimiter is %q.", reader.Comma)
+	}
 	if err != nil {
 		t.handleErr(err)
 		return


### PR DESCRIPTION
I lost a lot of time trying to debug why a CSV was failing, turned out it was comma separated , but was read with a tab delimited reader.  This could have helped.