### PR TITLE
update errors in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ CSV file:
     	step1 := optimus.Transform(begin, transforms.Fieldmap(fieldMappings))
     	step2 := optimus.Transform(step1, transforms.Valuemap(valueMappings))
     	end := optimus.Transform(step2, transforms.Map(arbitraryTransformFunction))
-    	csvSink.New(out)(end)
+	_ = csvSink.New(out)(end)
     }
 
 Here's one that uses chaining:

--- a/doc.go
+++ b/doc.go
@@ -33,7 +33,7 @@ Here's an example program that performs a set of field and value mappings on a C
 		step1 := optimus.Transform(begin, transforms.Fieldmap(fieldMappings))
 		step2 := optimus.Transform(step1, transforms.Valuemap(valueMappings))
 		end := optimus.Transform(step2, transforms.Map(arbitraryTransformFunction))
-		csvSink.New(out)(end)
+		_ = csvSink.New(out)(end)
 	}
 
 Here's one that uses chaining:


### PR DESCRIPTION
The example in the README does not properly indicate with an `_ = ` that a `Sink` returns an `error`