### PR TITLE
Added the "Explode" transform

### DIFF
--- a/transforms/README.md
+++ b/transforms/README.md
@@ -60,6 +60,25 @@ func Each(fn func(optimus.Row) error) optimus.TransformFunc
 Each returns a TransformFunc that makes no changes to the table, but calls the
 given function on every Row.
 
+#### func  Explode
+
+```go
+func Explode(keyToExplode string) optimus.TransformFunc
+```
+Explode returns a TransformFunc that takes a row that contains an array
+in the specified key and returns a duplicate of the row for each value in the array.
+For example, exploding on "school" for:
+```go
+optimus.Row{"id": "a", "school": []string{"Jones Elementary", "Cedar Middle"}}
+```
+becomes
+```go
+[]optimus.Row{
+    {"id": "a", "school": "Jones Elementary"},
+    {"id": "a", "school": "Cedar Middle"},
+}
+```
+
 #### func  Fieldmap
 
 ```go

--- a/transforms/transforms_test.go
+++ b/transforms/transforms_test.go
@@ -263,6 +263,33 @@ var transformEqualities = []tests.TableCompareConfig{
 			})
 		},
 	},
+	{
+		Name: "Explode",
+		Actual: func(optimus.Table, interface{}) optimus.Table {
+            explodeInput := []optimus.Row{
+                {"header1": "value1", "header2": []string{"valueA", "valueB","valueC"}},
+                {"header1": "value3", "header2": []string{"valueD", "valueE","valueF"}},
+                {"header1": "value5", "header2": []string{"valueG", "valueH","valueI"}},
+                //non-slice values should pass through unaltered
+                {"header1": "value7", "header2": "valueJ"},
+            }
+			return optimus.Transform(slice.New(explodeInput), Explode("header2"))
+		},
+		Expected: func(optimus.Table, interface{}) optimus.Table {
+			return slice.New([]optimus.Row{
+				{"header1": "value1", "header2": "valueA"},
+				{"header1": "value1", "header2": "valueB"},
+				{"header1": "value1", "header2": "valueC"},
+				{"header1": "value3", "header2": "valueD"},
+				{"header1": "value3", "header2": "valueE"},
+				{"header1": "value3", "header2": "valueF"},
+				{"header1": "value5", "header2": "valueG"},
+				{"header1": "value5", "header2": "valueH"},
+				{"header1": "value5", "header2": "valueI"},
+				{"header1": "value7", "header2": "valueJ"},
+			})
+		},
+	},
 }
 
 func TestJoinMergePairs(t *testing.T) {


### PR DESCRIPTION
This will be useful for the mongo->redshift pipeline. Right now, we
can't create useful "many to many" Foreign Key tables such as school
admin IDs linked to the schools they work with. We can't create such
tables, because we have no way of expanding (or "exploding") the array
of schools associated with the admin object into a set of rows for sql

Other places this transform be useful in bringing data into redshift:
- Coteachers for sections
- Students for sections
- Auth types for launchpads
- Grants for oauthtokens
- Permissions for students/teachers/sections
- Tags for oauthclients